### PR TITLE
fix: use uintptr_t

### DIFF
--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -12,12 +12,12 @@
 #include <wasmtime/error.h>
 
 #ifndef WASI_API_EXTERN
-#ifdef _WIN32
+#if defined _WIN32  && !defined(__MINGW32__) && !defined(LIBWASM_STATIC)
 #define WASI_API_EXTERN __declspec(dllimport)
 #else
 #define WASI_API_EXTERN
-#endif
-#endif
+#endif // _WIN32 or else
+#endif // WASI_API_EXTERN
 
 #ifdef __cplusplus
 #include <cstdint>

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -4,7 +4,6 @@ use crate::{wasm_byte_vec_t, wasmtime_error_t};
 use anyhow::{anyhow, Result};
 use cap_std::ambient_authority;
 use std::collections::HashMap;
-use std::ffi::c_void;
 use std::ffi::CStr;
 use std::fs::File;
 #[cfg(unix)]
@@ -330,21 +329,68 @@ pub extern "C" fn wasi_ctx_new() -> Box<WasiCtx> {
     Box::new(WasiCtxBuilder::new().build())
 }
 
+#[cfg(unix)]
 #[no_mangle]
 pub unsafe extern "C" fn wasi_ctx_insert_file(
-    ctx: &mut WasiCtx,    // input, wasi_ctx_t.
-    guest_fd: u32,        // input, uint32_t: guest file descriptor
-    host_fd: *mut c_void, // input, void*: file descriptor, int on Linux, HANDLE on Windows
-    access_mode: u32,     // input, uint32_t: 0'b1 = Read-only, 0'b10 = Write-only, 0'b11 = RW
+    ctx: &mut WasiCtx, // input, wasi_ctx_t.
+    guest_fd: u32,     // input, uint32_t: guest file descriptor
+    host_fd: RawFd,    // input, int: file descriptor
+    access_mode: u32,  // input, uint32_t: 0'b1 = Read-only, 0'b10 = Write-only, 0'b11 = RW
 ) -> Option<Box<wasmtime_error_t>> {
-    let access_mode = FileAccessMode::from_bits_truncate(access_mode);
-
     // SAFETY: caller should make sure there is no other owner for the file descriptor.
     // Calling `from_raw_fd`/`from_raw_handle` essentially assumes the exclusive ownership.
-    #[cfg(unix)]
-    let f = File::from_raw_fd(host_fd as RawFd);
-    #[cfg(windows)]
-    let f = File::from_raw_handle(host_fd as RawHandle);
+    let file = File::from_raw_fd(host_fd);
+    _wasi_ctx_insert_file(ctx, guest_fd, file, access_mode)
+}
+
+#[cfg(windows)]
+#[no_mangle]
+pub unsafe extern "C" fn wasi_ctx_insert_file(
+    ctx: &mut WasiCtx,  // input, wasi_ctx_t.
+    guest_fd: u32,      // input, uint32_t: guest file descriptor
+    host_fd: RawHandle, // input, HANDLE: file descriptor
+    access_mode: u32,   // input, uint32_t: 0'b1 = Read-only, 0'b10 = Write-only, 0'b11 = RW
+) -> Option<Box<wasmtime_error_t>> {
+    // SAFETY: caller should make sure there is no other owner for the file descriptor.
+    // Calling `from_raw_fd`/`from_raw_handle` essentially assumes the exclusive ownership.
+    let file = File::from_raw_handle(host_fd);
+    _wasi_ctx_insert_file(ctx, guest_fd, file, access_mode)
+}
+
+#[cfg(unix)]
+#[no_mangle]
+pub unsafe extern "C" fn wasi_ctx_push_file(
+    ctx: &mut WasiCtx,  // input, wasi_ctx_t.
+    host_fd: RawFd,     // input, int: file descriptor
+    access_mode: u32,   // input, uint32_t: 0'b1 = Read-only, 0'b10 = Write-only, 0'b11 = RW
+    guest_fd: &mut u32, // output, uint32_t: guest file descriptor
+) -> Option<Box<wasmtime_error_t>> {
+    // SAFETY: caller should make sure there is no other owner for the file descriptor.
+    // Calling `from_raw_fd`/`from_raw_handle` essentially assumes the exclusive ownership.
+    let file = File::from_raw_fd(host_fd);
+    _wasi_ctx_push_file(ctx, file, access_mode, guest_fd)
+}
+
+#[cfg(windows)]
+#[no_mangle]
+pub unsafe extern "C" fn wasi_ctx_push_file(
+    ctx: &mut WasiCtx,  // input, wasi_ctx_t.
+    host_fd: RawHandle, // input, HANDLE: file descriptor
+    access_mode: u32,   // input, uint32_t: 0'b1 = Read-only, 0'b10 = Write-only, 0'b11 = RW
+    guest_fd: &mut u32, // output, uint32_t: guest file descriptor
+) -> Option<Box<wasmtime_error_t>> {
+    // SAFETY: caller should make sure there is no other owner for the file descriptor.
+    // Calling `from_raw_fd`/`from_raw_handle` essentially assumes the exclusive ownership.
+    let file = File::from_raw_handle(host_fd);
+    _wasi_ctx_push_file(ctx, file, access_mode, guest_fd)
+}
+
+fn _wasi_ctx_insert_file(
+    ctx: &mut WasiCtx,
+    guest_fd: u32,
+    file: File,
+    access_mode: u32,
+) -> Option<Box<wasmtime_error_t>> {
     #[cfg(not(any(windows, unix)))]
     {
         // error instead of panic, to be friendly :)
@@ -352,28 +398,20 @@ pub unsafe extern "C" fn wasi_ctx_insert_file(
             "unsupported platform"
         )))));
     }
-    let f = cap_std::fs::File::from_std(f);
+    let access_mode = FileAccessMode::from_bits_truncate(access_mode);
+    let f = cap_std::fs::File::from_std(file);
     let f = wasmtime_wasi::sync::file::File::from_cap_std(f);
     ctx.insert_file(guest_fd, Box::new(f), access_mode);
 
     None
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn wasi_ctx_push_file(
+fn _wasi_ctx_push_file(
     ctx: &mut WasiCtx,
-    host_fd: u32,
+    file: File,
     access_mode: u32,
     guest_fd: &mut u32,
 ) -> Option<Box<wasmtime_error_t>> {
-    let access_mode = FileAccessMode::from_bits_truncate(access_mode);
-
-    // SAFETY: caller should make sure there is no other owner for the file descriptor.
-    // Calling `from_raw_fd`/`from_raw_handle` essentially assumes the exclusive ownership.
-    #[cfg(unix)]
-    let f = File::from_raw_fd(host_fd as RawFd);
-    #[cfg(windows)]
-    let f = File::from_raw_handle(host_fd as RawHandle);
     #[cfg(not(any(windows, unix)))]
     {
         // error instead of panic, to be friendly :)
@@ -381,7 +419,8 @@ pub unsafe extern "C" fn wasi_ctx_push_file(
             "unsupported platform"
         )))));
     }
-    let f = cap_std::fs::File::from_std(f);
+    let access_mode = FileAccessMode::from_bits_truncate(access_mode);
+    let f = cap_std::fs::File::from_std(file);
     let f = wasmtime_wasi::sync::file::File::from_cap_std(f);
 
     match ctx.push_file(Box::new(f), access_mode) {


### PR DESCRIPTION
This time it does work!

Recap: we are trying to replace the `void*` with `uintptr` or something else, so that we don't suffer from misuse of `unsafe.Pointer`s